### PR TITLE
Fix Elite CS-series SDK resilience

### DIFF
--- a/include/Common/TcpServer.hpp
+++ b/include/Common/TcpServer.hpp
@@ -6,6 +6,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <string>
 #include <thread>
 #include <vector>
 
@@ -38,9 +39,10 @@ class TcpServer : public std::enable_shared_from_this<TcpServer> {
      *
      * @param port Listen port
      * @param recv_buf_size
+     * @param label Human-readable name for this port, included in log messages
      * @note Ensure that the start() method has been called before instantiation
      */
-    TcpServer(int port, int recv_buf_size);
+    TcpServer(int port, int recv_buf_size, std::string label = "");
 
     /**
      * @brief Destroy the Tcp Server object
@@ -84,6 +86,7 @@ class TcpServer : public std::enable_shared_from_this<TcpServer> {
     std::shared_ptr<boost::asio::io_context> io_context_;
 
    private:
+    std::string label_;
     // Save connected client. In this project, each server is only connected to one client.
     std::shared_ptr<boost::asio::ip::tcp::socket> socket_;
     std::vector<uint8_t> read_buffer_;

--- a/include/Control/ControlCommon.hpp
+++ b/include/Control/ControlCommon.hpp
@@ -12,6 +12,10 @@ static const int POS_ZOOM_RATIO = 1000000;
 static const int COMMON_ZOOM_RATIO = 1000000;
 static const int TIME_ZOOM_RATIO = 1000;
 
+static constexpr const char* REVERSE_PORT_NAME        = "Reverse Port";
+static constexpr const char* TRAJECTORY_PORT_NAME     = "Trajectory Port";
+static constexpr const char* SCRIPT_COMMAND_PORT_NAME = "Script Command Port";
+
 } // namespace CONTROL
 
 } // namespace ELITE

--- a/include/Control/ReversePort.hpp
+++ b/include/Control/ReversePort.hpp
@@ -3,6 +3,7 @@
 
 #include "TcpServer.hpp"
 #include <memory>
+#include <string>
 
 namespace ELITE
 {
@@ -16,8 +17,8 @@ protected:
     }
 
 public:
-    ReversePort(int port, int buffer_size = 4) {
-        server_ = std::make_shared<TcpServer>(port, 4);
+    ReversePort(int port, int buffer_size = 4, std::string label = "") {
+        server_ = std::make_shared<TcpServer>(port, buffer_size, std::move(label));
     }
     ~ReversePort() = default;
 

--- a/include/EliteException.hpp
+++ b/include/EliteException.hpp
@@ -46,7 +46,7 @@ public:
         DASHBOARD_NOT_EXPECT_RECIVE,
         /// open file fail
         FILE_OPEN_FAIL,
-        /// The "s_io_context_ptr_" point is nullptr, if throw this expection, SDK had a bug
+        /// The "s_io_context_ptr_" point is nullptr, if throw this exception, SDK had a bug
         TCP_SERVER_CONTEXT_NULL,
     };
 

--- a/include/Primary/PrimaryPort.hpp
+++ b/include/Primary/PrimaryPort.hpp
@@ -5,6 +5,7 @@
 #include "DataType.hpp"
 
 #include <boost/asio.hpp>
+#include <chrono>
 #include <string>
 #include <thread>
 #include <memory>
@@ -16,6 +17,15 @@
 namespace ELITE
 {
 
+/**
+ * Manages the TCP connection to the robot's primary port (30001/30002) and
+ * runs a background thread that continuously receives and parses status frames.
+ *
+ * Resilience: when the robot is unreachable, the background thread generates
+ * errors at its poll rate. Three time-gated log throttles (last_no_conn_log_time_,
+ * last_conn_fail_log_time_, last_head_err_log_time_) cap repeated error messages
+ * to at most one per 5 seconds so the log remains readable during outages.
+ */
 class PrimaryPort
 {
 private:
@@ -27,7 +37,7 @@ private:
     std::mutex socket_mutex_;
     boost::asio::io_context io_context_;
     std::unique_ptr<boost::asio::ip::tcp::socket> socket_ptr_;
-    
+
     // The buffer of package head
     std::vector<uint8_t> message_head_;
     // The buffer of package body
@@ -38,7 +48,11 @@ private:
     std::unique_ptr<std::thread> socket_async_thread_;
     std::mutex mutex_;
     bool socket_async_thread_alive_;
-    
+    // Log throttle gates — each suppresses its associated error to at most 1 per 5 s
+    std::chrono::steady_clock::time_point last_no_conn_log_time_{};
+    std::chrono::steady_clock::time_point last_conn_fail_log_time_{};
+    std::chrono::steady_clock::time_point last_head_err_log_time_{};
+
     /**
      * @brief The background thread.
      *  Receive and parser package.

--- a/include/Rtsi/RtsiIOInterface.hpp
+++ b/include/Rtsi/RtsiIOInterface.hpp
@@ -18,6 +18,7 @@
 #include <Elite/VersionInfo.hpp>
 
 #include <atomic>
+#include <functional>
 #include <memory>
 #include <string>
 #include <thread>
@@ -67,6 +68,14 @@ class RtsiIOInterface : public RtsiClientInterface {
      * A tuple type where the data is, in order, major version, minor version, bugfix, and build.
      */
     ELITE_EXPORT virtual VersionInfo getControllerVersion();
+
+    /**
+     * @brief Register a callback invoked when the recv thread exits due to an error.
+     *        The callback is called from the recv thread before it terminates.
+     *
+     * @param cb Callback function (no arguments, no return value)
+     */
+    ELITE_EXPORT void setDisconnectCallback(std::function<void()> cb);
 
     /**
      * @brief Set the robot speed scaling
@@ -476,6 +485,7 @@ class RtsiIOInterface : public RtsiClientInterface {
     std::unique_ptr<std::thread> recv_thread_;
     std::atomic<bool> is_recv_thread_alive_;
     VersionInfo controller_version_;
+    std::function<void()> disconnect_cb_;
 
     /**
      * @brief Continuously receive and parse data messages.

--- a/source/Common/EliteException.cpp
+++ b/source/Common/EliteException.cpp
@@ -20,7 +20,7 @@ const char* EliteException::exceptionCodeToString(const Code& ec) {
     case Code::ILLEGAL_PARAM:
         return "parametric is illegal";
     case Code::DASHBOARD_NOT_EXPECT_RECIVE:
-        return "dashboard not expect recive";
+        return "dashboard did not expect to receive";
     case Code::TCP_SERVER_CONTEXT_NULL:
         return "tcp server io_context is nullptr";
     default:

--- a/source/Common/TcpServer.cpp
+++ b/source/Common/TcpServer.cpp
@@ -1,11 +1,12 @@
 #include "TcpServer.hpp"
 #include <iostream>
+#include <string>
 #include "EliteException.hpp"
 #include "Log.hpp"
 
 namespace ELITE {
 
-TcpServer::TcpServer(int port, int recv_buf_size) : read_buffer_(recv_buf_size) {
+TcpServer::TcpServer(int port, int recv_buf_size, std::string label) : read_buffer_(recv_buf_size), label_(std::move(label)) {
     if (!s_io_context_ptr_) {
         throw EliteException(EliteException::Code::TCP_SERVER_CONTEXT_NULL);
     }
@@ -65,9 +66,9 @@ void TcpServer::doAccept() {
                 self->socket_ = new_socket;
                 auto local_point = self->socket_->local_endpoint(ignore_ec);
                 auto remote_point = self->socket_->remote_endpoint(ignore_ec);
-                ELITE_LOG_INFO("TCP port %d accept client: %s:%d %s", local_point.port(),
-                               remote_point.address().to_string().c_str(), remote_point.port(),
-                               boost::system::system_error(ec).what());
+                std::string label_str = self->label_.empty() ? "" : " (" + self->label_ + ")";
+                ELITE_LOG_INFO("TCP port %d%s accept: arm controller connected from %s:%d", local_point.port(),
+                               label_str.c_str(), remote_point.address().to_string().c_str(), remote_point.port());
                 // Start async read
                 self->doRead(new_socket);
             } else {
@@ -106,10 +107,18 @@ void TcpServer::doRead(std::shared_ptr<boost::asio::ip::tcp::socket> sock) {
                     boost::system::error_code ignore_ec;
                     auto local_point = sock->local_endpoint(ignore_ec);
                     auto remote_point = sock->remote_endpoint(ignore_ec);
+                    std::string label_str = self->label_.empty() ? "" : " (" + self->label_ + ")";
                     self->closeSocket(sock, ignore_ec);
-                    ELITE_LOG_INFO("TCP port %d close client: %s:%d %s. Reason: %s", local_point.port(),
-                                   remote_point.address().to_string().c_str(), remote_point.port(),
-                                   boost::system::system_error(ignore_ec).what(), boost::system::system_error(ec).what());
+                    if (ec == boost::asio::error::eof) {
+                        ELITE_LOG_INFO("TCP port %d%s closed: arm controller %s:%d disconnected",
+                                       local_point.port(), label_str.c_str(),
+                                       remote_point.address().to_string().c_str(), remote_point.port());
+                    } else {
+                        ELITE_LOG_INFO("TCP port %d%s closed: %s:%d connection error - %s",
+                                       local_point.port(), label_str.c_str(),
+                                       remote_point.address().to_string().c_str(), remote_point.port(),
+                                       boost::system::system_error(ec).what());
+                    }
                 }
             }
         }

--- a/source/Control/ReverseInterface.cpp
+++ b/source/Control/ReverseInterface.cpp
@@ -5,7 +5,7 @@
 
 using namespace ELITE;
 
-ReverseInterface::ReverseInterface(int port) : ReversePort(port, 4) {
+ReverseInterface::ReverseInterface(int port) : ReversePort(port, 4, CONTROL::REVERSE_PORT_NAME) {
     server_->startListen();
 }
 

--- a/source/Control/ScriptCommandInterface.cpp
+++ b/source/Control/ScriptCommandInterface.cpp
@@ -5,7 +5,7 @@
 namespace ELITE
 {
 
-ScriptCommandInterface::ScriptCommandInterface(int port) : ReversePort(port, 4) {
+ScriptCommandInterface::ScriptCommandInterface(int port) : ReversePort(port, 4, CONTROL::SCRIPT_COMMAND_PORT_NAME) {
     server_->startListen();
 }
 

--- a/source/Control/TrajectoryInterface.cpp
+++ b/source/Control/TrajectoryInterface.cpp
@@ -6,7 +6,7 @@
 
 using namespace ELITE;
 
-TrajectoryInterface::TrajectoryInterface(int port) : ReversePort(port, sizeof(TrajectoryMotionResult)) {
+TrajectoryInterface::TrajectoryInterface(int port) : ReversePort(port, sizeof(TrajectoryMotionResult), CONTROL::TRAJECTORY_PORT_NAME) {
     server_->setReceiveCallback([&](const uint8_t data[], int nb){
         if (nb != sizeof(TrajectoryMotionResult)) {
             return;

--- a/source/Primary/PrimaryPort.cpp
+++ b/source/Primary/PrimaryPort.cpp
@@ -9,6 +9,8 @@ namespace ELITE
 {
 using namespace std::chrono;
 
+static constexpr double kLogThrottleSeconds = 10.0;
+
 PrimaryPort::PrimaryPort() {
     message_head_.resize(HEAD_LENGTH);
 }
@@ -80,7 +82,7 @@ bool PrimaryPort::parserMessage() {
         // Throttled: this path is hit at the background thread poll rate when the robot
         // is unreachable. Emit at most one message per 5 s to keep the log readable.
         auto now = std::chrono::steady_clock::now();
-        if (std::chrono::duration<double>(now - last_no_conn_log_time_).count() >= 5.0) {
+        if (std::chrono::duration<double>(now - last_no_conn_log_time_).count() >= kLogThrottleSeconds) {
             ELITE_LOG_WARN("No connection to robot primary port to parse status dataframe");
             last_no_conn_log_time_ = now;
         }
@@ -97,7 +99,7 @@ bool PrimaryPort::parserMessage() {
             // Throttled: socket read errors occur continuously when the robot disconnects.
             // Suppress to at most one per 5 s while the background thread retries.
             auto now = std::chrono::steady_clock::now();
-            if (std::chrono::duration<double>(now - last_head_err_log_time_).count() >= 5.0) {
+            if (std::chrono::duration<double>(now - last_head_err_log_time_).count() >= kLogThrottleSeconds) {
                 ELITE_LOG_ERROR("Primary port receive package header exception: %s",
                     boost::system::system_error(ec).what());
                 last_head_err_log_time_ = now;
@@ -206,7 +208,7 @@ bool PrimaryPort::socketConnect(const std::string& ip, int port) {
             // Throttled: connection failures during reconnection attempts produce one
             // error per attempt without this gate. Limit to at most one per 5 s.
             auto now = std::chrono::steady_clock::now();
-            if (std::chrono::duration<double>(now - last_conn_fail_log_time_).count() >= 5.0) {
+            if (std::chrono::duration<double>(now - last_conn_fail_log_time_).count() >= kLogThrottleSeconds) {
                 ELITE_LOG_ERROR("Connect to robot primary port failure: %s", boost::system::system_error(connect_ec).what());
                 last_conn_fail_log_time_ = now;
             }

--- a/source/Primary/PrimaryPort.cpp
+++ b/source/Primary/PrimaryPort.cpp
@@ -50,7 +50,7 @@ void PrimaryPort::disconnect() {
 bool PrimaryPort::sendScript(const std::string& script) {
     std::lock_guard<std::mutex> lock(socket_mutex_);
     if (!socket_ptr_) {
-        ELITE_LOG_ERROR("Don't connect to robot primary port");
+        ELITE_LOG_ERROR("No connection available to robot primary port to send external control script");
         return false;
     }
     auto script_with_newline = std::make_shared<std::string>(script + "\n");
@@ -77,7 +77,13 @@ bool PrimaryPort::getPackage(std::shared_ptr<PrimaryPackage> pkg, int timeout_ms
 bool PrimaryPort::parserMessage() {
     std::lock_guard<std::mutex> lock(socket_mutex_);
     if (!socket_ptr_ || !socket_ptr_->is_open()) {
-        ELITE_LOG_WARN("Don't connect to robot primary port");
+        // Throttled: this path is hit at the background thread poll rate when the robot
+        // is unreachable. Emit at most one message per 5 s to keep the log readable.
+        auto now = std::chrono::steady_clock::now();
+        if (std::chrono::duration<double>(now - last_no_conn_log_time_).count() >= 5.0) {
+            ELITE_LOG_WARN("No connection to robot primary port to parse status dataframe");
+            last_no_conn_log_time_ = now;
+        }
         return false;
     }
     // Receive package head and parser it
@@ -88,7 +94,14 @@ bool PrimaryPort::parserMessage() {
             // Data not ready, non blocking mode returns normally
             return true;
         } else {
-            ELITE_LOG_ERROR("Primary port receive package head had expection: %s", boost::system::system_error(ec).what());
+            // Throttled: socket read errors occur continuously when the robot disconnects.
+            // Suppress to at most one per 5 s while the background thread retries.
+            auto now = std::chrono::steady_clock::now();
+            if (std::chrono::duration<double>(now - last_head_err_log_time_).count() >= 5.0) {
+                ELITE_LOG_ERROR("Primary port receive package head had exception: %s",
+                    boost::system::system_error(ec).what());
+                last_head_err_log_time_ = now;
+            }
             return false;
         }
     }
@@ -118,7 +131,7 @@ bool PrimaryPort::parserMessageBody(int type, int package_len) {
     }
     io_context_.run_for(std::chrono::steady_clock::duration(500ms));
     if (ec) {
-        ELITE_LOG_ERROR("Primary port receive package body had expection: %s", boost::system::system_error(ec).what());
+        ELITE_LOG_ERROR("Primary port receive package body had exception: %s", boost::system::system_error(ec).what());
         return false;
     }
     if (read_len != body_len) {
@@ -169,6 +182,7 @@ void PrimaryPort::socketAsyncLoop(const std::string& ip, int port) {
 bool PrimaryPort::socketConnect(const std::string& ip, int port) {
     try {
         std::lock_guard<std::mutex> lock(socket_mutex_);
+        socketDisconnect();  // Cancel pending ops and close old socket before creating a new one
         socket_ptr_.reset(new boost::asio::ip::tcp::socket(io_context_));
         socket_ptr_->open(boost::asio::ip::tcp::v4());
         socket_ptr_->set_option(boost::asio::ip::tcp::no_delay(true));
@@ -189,7 +203,13 @@ bool PrimaryPort::socketConnect(const std::string& ip, int port) {
         io_context_.run_for(std::chrono::steady_clock::duration(500ms));
         if (connect_ec) {
             socket_ptr_.reset();
-            ELITE_LOG_ERROR("Connect to robot primary port fail: %s", boost::system::system_error(connect_ec).what());
+            // Throttled: connection failures during reconnection attempts produce one
+            // error per attempt without this gate. Limit to at most one per 5 s.
+            auto now = std::chrono::steady_clock::now();
+            if (std::chrono::duration<double>(now - last_conn_fail_log_time_).count() >= 5.0) {
+                ELITE_LOG_ERROR("Connect to robot primary port fail: %s", boost::system::system_error(connect_ec).what());
+                last_conn_fail_log_time_ = now;
+            }
             return false;
         }
         // If the asynchronous operation completed successfully then the io_context

--- a/source/Primary/PrimaryPort.cpp
+++ b/source/Primary/PrimaryPort.cpp
@@ -50,7 +50,7 @@ void PrimaryPort::disconnect() {
 bool PrimaryPort::sendScript(const std::string& script) {
     std::lock_guard<std::mutex> lock(socket_mutex_);
     if (!socket_ptr_) {
-        ELITE_LOG_ERROR("No connection available to robot primary port to send external control script");
+        ELITE_LOG_ERROR("No connection to robot primary port available to send external control script");
         return false;
     }
     auto script_with_newline = std::make_shared<std::string>(script + "\n");
@@ -98,7 +98,7 @@ bool PrimaryPort::parserMessage() {
             // Suppress to at most one per 5 s while the background thread retries.
             auto now = std::chrono::steady_clock::now();
             if (std::chrono::duration<double>(now - last_head_err_log_time_).count() >= 5.0) {
-                ELITE_LOG_ERROR("Primary port receive package head had exception: %s",
+                ELITE_LOG_ERROR("Primary port receive package header exception: %s",
                     boost::system::system_error(ec).what());
                 last_head_err_log_time_ = now;
             }
@@ -207,7 +207,7 @@ bool PrimaryPort::socketConnect(const std::string& ip, int port) {
             // error per attempt without this gate. Limit to at most one per 5 s.
             auto now = std::chrono::steady_clock::now();
             if (std::chrono::duration<double>(now - last_conn_fail_log_time_).count() >= 5.0) {
-                ELITE_LOG_ERROR("Connect to robot primary port fail: %s", boost::system::system_error(connect_ec).what());
+                ELITE_LOG_ERROR("Connect to robot primary port failure: %s", boost::system::system_error(connect_ec).what());
                 last_conn_fail_log_time_ = now;
             }
             return false;

--- a/source/Rtsi/RtsiClient.cpp
+++ b/source/Rtsi/RtsiClient.cpp
@@ -33,8 +33,13 @@ bool RtsiClient::connect(const std::string& ip, int port) {
                 connection_state = ConnectionState::CONNECTED;
             }
         });
-        io_context_.run();
-        
+        io_context_.run_for(std::chrono::seconds(5));
+        if (connection_state != ConnectionState::CONNECTED) {
+            ELITE_LOG_ERROR("Robot RTSI connection to %s:%d timed out or failed", ip.c_str(), port);
+            socketDisconnect();
+            return false;
+        }
+
     } catch(const boost::system::system_error &error) {
         ELITE_LOG_WARN("Robot RTSI connection failed for %s:%d: %s", ip.c_str(), port, error.what());
         return false;

--- a/source/Rtsi/RtsiClient.cpp
+++ b/source/Rtsi/RtsiClient.cpp
@@ -33,6 +33,7 @@ bool RtsiClient::connect(const std::string& ip, int port) {
                 connection_state = ConnectionState::CONNECTED;
             }
         });
+        // Wait for the asynchronous connect operation to complete or timeout after 5 seconds.
         io_context_.run_for(std::chrono::seconds(5));
         if (connection_state != ConnectionState::CONNECTED) {
             ELITE_LOG_ERROR("Robot RTSI connection to %s:%d timed out or failed", ip.c_str(), port);

--- a/source/Rtsi/RtsiIOInterface.cpp
+++ b/source/Rtsi/RtsiIOInterface.cpp
@@ -583,6 +583,10 @@ void RtsiIOInterface::setupRecipe() {
     output_recipe_ = setupOutputRecipe(output_recipe_string_, target_frequency_);
 }
 
+void RtsiIOInterface::setDisconnectCallback(std::function<void()> cb) {
+    disconnect_cb_ = std::move(cb);
+}
+
 void RtsiIOInterface::recvLoop() {
     // Calculate the ideal cycle time.
     double period_ms = (1 / target_frequency_) * 1000;
@@ -595,8 +599,12 @@ void RtsiIOInterface::recvLoop() {
                     input_new_cmd_ = false;
                 }
         } catch(const std::exception& e) {
+            ELITE_LOG_ERROR("RTSI recv thread caught exception and is stopping: %s", e.what());
             is_recv_thread_alive_ = false;
+            if (disconnect_cb_) {
+                disconnect_cb_();
+            }
         }
     }
-    ELITE_LOG_INFO("RTSI IO interface sync thread dropped");
+    ELITE_LOG_INFO("RTSI IO interface sync thread stopped");
 }

--- a/source/resources/external_control.script
+++ b/source/resources/external_control.script
@@ -58,6 +58,8 @@ global steptime
 global trajectory_point_num
 global cmd_servo_joints
 
+textmsg("ExternalControl: Script started")
+
 def trajectoryThread():
     global trajectory_point_num
     blend_radius = int()
@@ -231,6 +233,10 @@ while control_mode > MODE_STOPPED:
             elif control_mode == MODE_SERVOJ:
                 cmd_servo_joints = get_actual_joint_positions()
                 move_thread_handle = start_thread(servoThread, ())
+            
+            # Log when a script stop is commanded externally
+            elif control_mode == MODE_STOPPED:
+                textmsg("ExternalControl: Script stopped")
             
         # Update the motion commands with new parameters
         if control_mode == MODE_SERVOJ:


### PR DESCRIPTION
## Related Issue(s)
Linear: [Elite ROS2 Driver Resilience](https://linear.app/clean-botix/issue/SW-526/elite-ros2-driver-resilience)

This PR is interrelated with 2 others:
1. https://github.com/Tectrix-Cleanlogix/OptimusClean-MoveItPro/pull/152
1. https://github.com/Clean-Botix/Elite_Robots_CS_ROS2_Driver/pull/6

## Background
Elite’s ROS2 Driver + SDK have lacked resilience from the earliest versions. Proper connection retry attempts at start up (if the Driver starts up before the arm is booted) were added by us. This work expands on that to handle all mode transitions and communication interruptions that cause the Driver to silently fail (e.g. unrecoverable mode with no logging) or outright crash.

## Proposed Changes
* Add full error handling, state transition handling, health checks, and network interruption/retry handling.
* Add clear and usable (throttled) logging to failure states, mode transitions, and reconnection attempts.

## Checklist

- [x] I have added the corresponding label for the types of changes
- [x] I have added the "hardware test needed" if applicable
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added all the necessary documentation
   - Code comments
   - Revisions to [_Elite CS Series SDK and ROS2 Driver_](https://docs.google.com/document/d/1j7VlFhRV5iHsSt6p_6tuoZsJnNQ6oeozQx4UJXuptyg/) Google Doc discussing the list of issues resolved and code changes made.
- [x] Lint and unit tests pass locally with these changes

## How to Test
Test instructions are found in the interdependent ROS2 Driver PR:
* https://github.com/Clean-Botix/Elite_Robots_CS_ROS2_Driver/pull/6